### PR TITLE
Podcast Parsing

### DIFF
--- a/app/project.clj
+++ b/app/project.clj
@@ -31,7 +31,8 @@
                  [clj-http "2.0.0"]
                  [org.postgresql/postgresql "9.4-1203-jdbc41"]
                  [org.immutant/web "2.1.0"]
-                 [test2junit "1.1.3"]]
+                 [test2junit "1.1.3"]
+                 [org.clojars.freemarmoset/feedparser-clj "0.6.1"]]
 
   :min-lein-version "2.0.0"
   :uberjar-name "app.jar"

--- a/app/src/app/services/podcast.clj
+++ b/app/src/app/services/podcast.clj
@@ -1,11 +1,48 @@
 (ns app.services.podcast
   (:require [clj-http.client :as httpclient]
-            [clojure.xml :as xml]))
+            [feedparser-clj.core :as feed-parser]))
+
+(defn- get-title
+  [f]
+  (:title f))
+
+(defn- get-entries
+  [f]
+  (:entries f))
+
+(defn- get-description
+  [f]
+  (:description f))
+
+(defn- get-logo
+  [f]
+  (:image f))
+
+(defn- build-item
+  [e]
+  {
+    :title          (:title e)
+    :description    (:value (:description e))
+    :url            (:url (first (:enclosures e)))
+    :publishedDate  (:published-date e)
+    :duration       (:length (first (:enclosures e)))
+    })
+
+(defn- get-items
+  [f]
+  (map build-item (get-entries f)))
+
+(defn- get-copyright
+  [f]
+  (:copyright f))
 
 (defn parse-feed
   [feed-url]
-  (if (nil? feed-url)
-    feed-url
-    (-> feed-url
-        (httpclient/get)
-        (:body))))
+  (let [feed (feed-parser/parse-feed feed-url)]
+    {
+      :title        (get-title feed)
+      :logo         (get-logo feed)
+      :description  (get-description feed)
+      :copyright    (get-copyright feed)
+      :items        (get-items feed)
+    }))


### PR DESCRIPTION
Bam. Here's the start of podcast parsing, no zippers required. I'm testing this against different podcasts still and I'm seeing a few issues (notably, logo isnt getting pulled in via iTunes feeds).

I'll continue looking into it, but what we can do for now is something like this (if we cant get a logo).

![ab1](https://cloud.githubusercontent.com/assets/1455979/24487413/262379b2-14c4-11e7-936e-a1c2da4870f8.png)


Expect this to simply be a temporary image fix, as I plan on figuring out what's not working with iTunes feeds and writing custom parser pieces or contributing to ROME.